### PR TITLE
Bump to v2.3.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,14 +105,14 @@ dependencies:
   - name: bundler
     version: 1.7.12
     uri: https://pivotal-buildpacks.s3.amazonaws.com/ruby/binaries/lucid64/bundler-1.7.12.tgz
-    md5: ab7ebd9c9e945e3ea91c8dd0c6aa3562
+    sha256: 09b15ac14f7b46ac6d0a85102cef4671d95f6d6581e01dbcdbab0e64df83c4d5
     cf_stacks:
       - lucid64
       - cflinuxfs2
   - name: ruby
     version: 2.1.4
     uri: https://pivotal-buildpacks.s3.amazonaws.com/ruby/binaries/lucid64/ruby-2.1.4.tgz
-    md5: 72b4d193a11766e2a4c45c1fed65754c
+    sha256: e3e6023764357324260e9efab1f1690b7bcc0c69f82e8589797b262eb5df2831
     cf_stacks:
       - lucid64
 
@@ -140,7 +140,7 @@ A list of regular expressions that extract and map the values of `name` and `ver
 ## dependencies (required)
 
 
-The dependencies key specifies the name, version, uri, md5, and the
+The dependencies key specifies the name, version, uri, sha256, and the
 cf_stacks (the root file system(s) for which it is compiled for) of a
 resource which the buildpack attempts to download during staging. By
 specifying them here, the packager can download them and install them
@@ -151,7 +151,7 @@ All keys are required:
 - `name`, `version`, and `uri`:
 Required for `url_to_dependency_map` to work. Make sure to create a new entry in the `url_to_dependency_map` if a matching regex does not exist for the dependency to be curled.
 
-- `md5`:
+- `sha256`:
 Required to ensure that dependencies being packaged for 'cached' mode have not been compromised
 
 - `cf_stacks`:

--- a/buildpack-packager.gemspec
+++ b/buildpack-packager.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'activesupport', '~> 4.1'
   spec.add_dependency 'kwalify', '~> 0'
+  spec.add_dependency 'semantic'
   spec.add_dependency 'terminal-table', '~> 1.4'
 
   spec.add_development_dependency 'bundler', '~> 1.7'

--- a/lib/buildpack/manifest_validator.rb
+++ b/lib/buildpack/manifest_validator.rb
@@ -87,7 +87,7 @@ module Buildpack
     private
 
     def version_exists?(default_dependency, dependency_versions)
-      major, minor, patch = default_dependency.version.split('.')
+      major, minor, patch = default_dependency.version.to_s.split('.')
       major = major.gsub('v','')
 
       if patch == 'x'

--- a/lib/buildpack/packager/manifest_schema.yml
+++ b/lib/buildpack/packager/manifest_schema.yml
@@ -67,7 +67,7 @@ mapping:
            required:  yes
            sequence:
              - type: str
-               enum: [ lucid64, cflinuxfs2, windows2012R2 ]
+               enum: [ lucid64, cflinuxfs2, windows2012R2, windows2016 ]
   "exclude_files":
     type:      seq
     required:  yes

--- a/lib/buildpack/packager/manifest_schema.yml
+++ b/lib/buildpack/packager/manifest_schema.yml
@@ -59,7 +59,7 @@ mapping:
            required:  no
            sequence:
              - type: str
-         "md5":
+         "sha256":
            type: str
            required:  yes
          "cf_stacks":

--- a/lib/buildpack/packager/package.rb
+++ b/lib/buildpack/packager/package.rb
@@ -109,7 +109,7 @@ module Buildpack
       end
 
       def ensure_correct_dependency_checksum(local_cached_file:, dependency:, from_local_cache:)
-        if dependency['md5'] != Digest::MD5.file(local_cached_file).hexdigest
+        if dependency['sha256'] != Digest::SHA256.file(local_cached_file).hexdigest
           if from_local_cache
             FileUtils.rm_rf(local_cached_file)
 
@@ -124,7 +124,7 @@ module Buildpack
               "File: #{dependency['name']}, version: #{dependency['version']} downloaded at location #{dependency['uri']}\n\tis reporting a different checksum than the one specified in the manifest."
           end
         else
-          puts "  #{dependency['name']} version #{dependency['version']} matches the manifest provided md5 checksum of #{dependency['md5']}\n\n"
+          puts "  #{dependency['name']} version #{dependency['version']} matches the manifest provided sha256 checksum of #{dependency['sha256']}\n\n"
         end
       end
 

--- a/lib/buildpack/packager/version.rb
+++ b/lib/buildpack/packager/version.rb
@@ -1,5 +1,5 @@
 module Buildpack
   module Packager
-    VERSION = '2.3.8'.freeze
+    VERSION = '2.3.9'.freeze
   end
 end

--- a/lib/buildpack/packager/version.rb
+++ b/lib/buildpack/packager/version.rb
@@ -1,5 +1,5 @@
 module Buildpack
   module Packager
-    VERSION = '2.3.9'.freeze
+    VERSION = '2.3.10'.freeze
   end
 end

--- a/lib/buildpack/packager/version.rb
+++ b/lib/buildpack/packager/version.rb
@@ -1,5 +1,5 @@
 module Buildpack
   module Packager
-    VERSION = '2.3.9'.freeze
+    VERSION = '2.3.8'.freeze
   end
 end

--- a/lib/buildpack/packager/version.rb
+++ b/lib/buildpack/packager/version.rb
@@ -1,5 +1,5 @@
 module Buildpack
   module Packager
-    VERSION = '2.3.10'.freeze
+    VERSION = '2.3.11'.freeze
   end
 end

--- a/spec/fixtures/buildpack-with-uri-credentials/manifest.yml
+++ b/spec/fixtures/buildpack-with-uri-credentials/manifest.yml
@@ -11,13 +11,13 @@ dependencies:
 - name: go
   version: 1.6.3
   uri: https://login:password@buildpacks.cloudfoundry.org/concourse-binaries/go/go1.6.3.linux-amd64.tar.gz
-  md5: 5f7bf9d61d2b0dd75c9e2cd7a87272cc
+  sha256: 5ac238cd321a66a35c646d61e4cafd922929af0800c78b00375312c76e702e11
   cf_stacks:
   - cflinuxfs2
 - name: godep
   version: v74
   uri: https://api-token:x-oauth-basic@buildpacks.cloudfoundry.org/concourse-binaries/godep/godep-v74-linux-x64.tgz
-  md5: 70220eee9f9e654e0b85887f696b6add
+  sha256: 6e6761b71e1518bf7716b3f383f10598afe5ce4592e6eea0184f17b85fd93813
   cf_stacks:
   - cflinuxfs2
 exclude_files:

--- a/spec/fixtures/buildpack-without-uri-credentials/manifest.yml
+++ b/spec/fixtures/buildpack-without-uri-credentials/manifest.yml
@@ -11,13 +11,13 @@ dependencies:
 - name: go
   version: 1.6.3
   uri: https://buildpacks.cloudfoundry.org/concourse-binaries/go/go1.6.3.linux-amd64.tar.gz
-  md5: 5f7bf9d61d2b0dd75c9e2cd7a87272cc
+  sha256: 5ac238cd321a66a35c646d61e4cafd922929af0800c78b00375312c76e702e11
   cf_stacks:
   - cflinuxfs2
 - name: godep
   version: v74
   uri: https://pivotal-buildpacks.s3.amazonaws.com/concourse-binaries/godep/godep-v74-linux-x64.tgz
-  md5: 70220eee9f9e654e0b85887f696b6add
+  sha256: 6e6761b71e1518bf7716b3f383f10598afe5ce4592e6eea0184f17b85fd93813
   cf_stacks:
   - cflinuxfs2
 exclude_files:

--- a/spec/fixtures/manifests/manifest_invalid-sha224.yml
+++ b/spec/fixtures/manifests/manifest_invalid-sha224.yml
@@ -5,14 +5,11 @@ url_to_dependency_map:
   - match: go(\d+\.\d+(\.\d+)?)
     name: go
     version: $1
-default_versions:
-  - name: go
-    version: 1.3
 dependencies:
   - name: go
     version: 1.2
     uri: http://go.googlecode.com/files/go1.2.linux-amd64.tar.gz
-    md6: 68901bbf8a04e71e0b30aa19c3946b21
+    sha224: 68901bbf8a04e71e0b30aa19c3946b21
     cf_stacks:
       - lucid64
       - cflinuxfs2

--- a/spec/fixtures/manifests/manifest_invalid-sha224_and_defaults.yml
+++ b/spec/fixtures/manifests/manifest_invalid-sha224_and_defaults.yml
@@ -5,11 +5,14 @@ url_to_dependency_map:
   - match: go(\d+\.\d+(\.\d+)?)
     name: go
     version: $1
+default_versions:
+  - name: go
+    version: 1.3
 dependencies:
   - name: go
     version: 1.2
     uri: http://go.googlecode.com/files/go1.2.linux-amd64.tar.gz
-    md6: 68901bbf8a04e71e0b30aa19c3946b21
+    sha244: 68901bbf8a04e71e0b30aa19c3946b21
     cf_stacks:
       - lucid64
       - cflinuxfs2

--- a/spec/fixtures/manifests/manifest_valid.yml
+++ b/spec/fixtures/manifests/manifest_valid.yml
@@ -10,7 +10,7 @@ dependencies:
   - name: go
     version: 1.2
     uri: http://go.googlecode.com/files/go1.2.linux-amd64.tar.gz
-    md5: 68901bbf8a04e71e0b30aa19c3946b21
+    sha256: c0ffee
     cf_stacks:
       - lucid64
       - cflinuxfs2

--- a/spec/fixtures/manifests/manifest_valid_new_deprecation_dates_no_url_map.yml
+++ b/spec/fixtures/manifests/manifest_valid_new_deprecation_dates_no_url_map.yml
@@ -5,7 +5,7 @@ dependencies:
   - name: go
     version: 1.2
     uri: http://go.googlecode.com/files/go1.2.linux-amd64.tar.gz
-    md5: 68901bbf8a04e71e0b30aa19c3946b21
+    sha256: c0ffee
     cf_stacks:
       - lucid64
       - cflinuxfs2

--- a/spec/fixtures/manifests/manifest_valid_plus_deprecation_dates.yml
+++ b/spec/fixtures/manifests/manifest_valid_plus_deprecation_dates.yml
@@ -10,7 +10,7 @@ dependencies:
   - name: go
     version: 1.2
     uri: http://go.googlecode.com/files/go1.2.linux-amd64.tar.gz
-    md5: 68901bbf8a04e71e0b30aa19c3946b21
+    sha256: c0ffee
     cf_stacks:
       - lucid64
       - cflinuxfs2

--- a/spec/fixtures/manifests/manifest_windows.yml
+++ b/spec/fixtures/manifests/manifest_windows.yml
@@ -4,7 +4,7 @@ dependencies:
 - name: hwc
   version: 3.0.0
   uri: https://buildpacks.cloudfoundry.org/dependencies/hwc/hwc-3.0.0-windows-amd64-acb65777.zip
-  md5: acb65777be759df87d7d288146d592f7
+  sha256: c0ffee
   cf_stacks:
   - windows2012R2
   - windows2016

--- a/spec/fixtures/manifests/manifest_windows.yml
+++ b/spec/fixtures/manifests/manifest_windows.yml
@@ -1,0 +1,13 @@
+---
+language: hwc
+dependencies:
+- name: hwc
+  version: 3.0.0
+  uri: https://buildpacks.cloudfoundry.org/dependencies/hwc/hwc-3.0.0-windows-amd64-acb65777.zip
+  md5: acb65777be759df87d7d288146d592f7
+  cf_stacks:
+  - windows2012R2
+  - windows2016
+pre_package: scripts/build.sh
+
+exclude_files: []

--- a/spec/helpers/file_system_helpers.rb
+++ b/spec/helpers/file_system_helpers.rb
@@ -28,8 +28,4 @@ module FileSystemHelpers
         .select { |name| name[/\/$/].nil? }
     end
   end
-
-  def get_md5_of_file(path)
-    Digest::MD5.file(path).hexdigest
-  end
 end

--- a/spec/integration/bin/buildpack_packager/download_caching_spec.rb
+++ b/spec/integration/bin/buildpack_packager/download_caching_spec.rb
@@ -20,7 +20,7 @@ describe 'reusing previously downloaded files' do
 
   let(:buildpack_dir) { Dir.mktmpdir('buildpack_') }
 
-  let(:md5) { get_md5_of_file(upstream_file_path) }
+  let(:sha256) { Digest::SHA256.file(upstream_file_path).hexdigest }
   let(:manifest) do
     {
       'exclude_files' => [],
@@ -30,7 +30,7 @@ describe 'reusing previously downloaded files' do
         'version' => '1.0',
         'name' => 'sample_download.ignore_me',
         'cf_stacks' => [],
-        'md5' => md5,
+        'sha256' => sha256,
         'uri' => upstream_file_uri
       }]
     }
@@ -64,13 +64,13 @@ describe 'reusing previously downloaded files' do
       expect(status).to be_success
     end
 
-    context 'however the file has changed, and the manifest is updated to reflect the new md5' do
+    context 'however the file has changed, and the manifest is updated to reflect the new sha256' do
       before do
         run_packager_binary(buildpack_dir, '--cached')
 
         create_upstream_file('sample_download.ignore_me', 'sample_download updated text')
-        new_md5 = get_md5_of_file(upstream_file_path)
-        manifest['dependencies'].first['md5'] = new_md5
+        new_sha256 = Digest::SHA256.file(upstream_file_path).hexdigest
+        manifest['dependencies'].first['sha256'] = new_sha256
         File.write(File.join(buildpack_dir, 'manifest.yml'), manifest.to_yaml)
       end
 

--- a/spec/integration/bin/buildpack_packager_spec.rb
+++ b/spec/integration/bin/buildpack_packager_spec.rb
@@ -24,7 +24,7 @@ dependencies:
   - name: fake_name
     version: 1.2
     uri: file://#{file_location}
-    md5: #{md5}
+    sha256: #{sha256}
     modules: ["one", "two", "three"]
     cf_stacks:
       - lucid64
@@ -58,14 +58,14 @@ dependencies:
   - name: fake_name
     version: 1.2
     uri: file://#{file_location}
-    md5: #{md5}
+    sha256: #{sha256}
     cf_stacks:
       - lucid64
       - cflinuxfs2
   - name: fake_name
     version: 1.1
     uri: file://#{deprecated_file_location}
-    md5: #{deprecated_md5}
+    sha256: #{deprecated_sha256}
     cf_stacks:
       - lucid64
       - cflinuxfs2
@@ -88,7 +88,7 @@ dependencies:
   - name: fake_name
     version: 1.2
     uri: file://#{file_location}
-    md5: md5
+    sha256: sha256
     cf_stacks: [cflinuxfs2]
 MANIFEST
     end
@@ -100,9 +100,9 @@ MANIFEST
   let(:buildpack_dir) { File.join(tmp_dir, 'sample-buildpack-root-dir') }
   let(:remote_dependencies_dir) { File.join(tmp_dir, 'remote_dependencies') }
   let(:file_location) { "#{remote_dependencies_dir}/dep1.txt" }
-  let(:md5) { Digest::MD5.file(file_location).hexdigest }
+  let(:sha256) { Digest::SHA256.file(file_location).hexdigest }
   let(:deprecated_file_location) { "#{remote_dependencies_dir}/dep2.txt" }
-  let(:deprecated_md5) { Digest::MD5.file(deprecated_file_location).hexdigest }
+  let(:deprecated_sha256) { Digest::SHA256.file(deprecated_file_location).hexdigest }
 
   let(:files_to_include) do
     [
@@ -365,7 +365,7 @@ MANIFEST
         end
 
         context 'vendored dependencies with invalid checksums' do
-          let(:md5) { 'InvalidMD5_123' }
+          let(:sha256) { 'InvalidSHA256_123' }
 
           specify do
             stdout, status = run_packager_binary(buildpack_dir, flags)

--- a/spec/integration/buildpack/directory_name_spec.rb
+++ b/spec/integration/buildpack/directory_name_spec.rb
@@ -9,7 +9,7 @@ module Buildpack
       "file://#{location}"
     end
 
-    let(:md5) { Digest::MD5.file(fake_file_uri.gsub(/file:\/\//, '')).hexdigest }
+    let(:sha256) { Digest::SHA256.file(fake_file_uri.gsub(/file:\/\//, '')).hexdigest }
 
     let(:manifest) do
       {
@@ -19,7 +19,7 @@ module Buildpack
           {
             'name' => 'fake',
             'uri' => fake_file_uri,
-            'md5' => md5
+            'sha256' => sha256
           }
         ]
       }

--- a/spec/integration/buildpack/packager_spec.rb
+++ b/spec/integration/buildpack/packager_spec.rb
@@ -17,7 +17,7 @@ module Buildpack
     end
     let(:translated_file_location) { 'file___' + file_location.gsub(/[:\/]/, '_') }
 
-    let(:md5) { Digest::MD5.file(file_location).hexdigest }
+    let(:sha256) { Digest::SHA256.file(file_location).hexdigest }
 
     let(:options) do
       {
@@ -41,7 +41,7 @@ module Buildpack
         dependencies: [{
           'version' => '1.0',
           'name' => 'etc_host',
-          'md5' => md5,
+          'sha256' => sha256,
           'uri' => "file://#{file_location}",
           'cf_stacks' => ['cflinuxfs2']
         }]
@@ -318,13 +318,13 @@ module Buildpack
               Packager.package(options.merge(force_download: true))
 
               expect(File).to exist(cached_file)
-              expect(Digest::MD5.file(cached_file).hexdigest).to eq md5
+              expect(Digest::SHA256.file(cached_file).hexdigest).to eq sha256
             end
           end
 
           context 'and the request fails' do
             let(:file_location) { 'fake-file-that-no-one-should-have.txt' }
-            let(:md5) { nil }
+            let(:sha256) { nil }
 
             it 'does not cache the file' do
               expect(File).to_not exist(cached_file)
@@ -350,7 +350,7 @@ module Buildpack
                 File.write(cached_file, 'asdf')
 
                 Packager.package(options.merge(force_download: true))
-                expect(Digest::MD5.file(cached_file).hexdigest).to eq md5
+                expect(Digest::SHA256.file(cached_file).hexdigest).to eq sha256
               end
             end
 
@@ -392,8 +392,8 @@ module Buildpack
     end
 
     describe 'when checking checksums' do
-      context 'with an invalid MD5' do
-        let(:md5) { 'wompwomp' }
+      context 'with an invalid SHA256' do
+        let(:sha256) { 'wompwomp' }
 
         context 'in cached mode' do
           let(:buildpack_mode) { :cached }

--- a/spec/integration/default_versions_spec.rb
+++ b/spec/integration/default_versions_spec.rb
@@ -42,9 +42,37 @@ exclude_files: []
 default_versions:
   - name: python
     version: 3.3.5
+  - name: pip
+    version: 3.x
+  - name: ruby
+    version: 5.5.x
 dependencies:
   - name: python
     version: 3.3.5
+    uri: http://example.com/
+    md5: 68901bbf8a04e71e0b30aa19c3946b21
+    cf_stacks:
+      - cflinuxfs2
+  - name: pip
+    version: 3.3.4
+    uri: http://example.com/
+    md5: 68901bbf8a04e71e0b30aa19c3946b21
+    cf_stacks:
+      - cflinuxfs2
+  - name: pip
+    version: 3.3.2
+    uri: http://example.com/
+    md5: 68901bbf8a04e71e0b30aa19c3946b21
+    cf_stacks:
+      - cflinuxfs2
+  - name: ruby
+    version: 5.4.3
+    uri: http://example.com/
+    md5: 68901bbf8a04e71e0b30aa19c3946b21
+    cf_stacks:
+      - cflinuxfs2
+  - name: ruby
+    version: 5.5.3
     uri: http://example.com/
     md5: 68901bbf8a04e71e0b30aa19c3946b21
     cf_stacks:
@@ -53,8 +81,9 @@ dependencies:
     }
 
     it 'emits no errors' do
-      _, status = run_packager_binary(buildpack_dir, flags)
+      stdout, status = run_packager_binary(buildpack_dir, flags)
 
+      puts stdout
       expect(status).to be_success
     end
   end
@@ -67,8 +96,12 @@ default_versions:
     version: 3.3.5
   - name: python
     version: 3.3.2
+  - name: pip
+    version: 7.7.x
+  - name: pip
+    version: 7.7.2
   - name: ruby
-    version: 4.3.5
+    version: 4.x
   - name: ruby
     version: 4.3.2
 dependencies:
@@ -90,6 +123,16 @@ dependencies:
   - name: ruby
     uri: https://a.org
     version: 4.3.2
+    md5: 3a2
+    cf_stacks: [cflinuxfs2]
+  - name: pip
+    uri: https://a.org
+    version: 7.7.7
+    md5: 3a2
+    cf_stacks: [cflinuxfs2]
+  - name: pip
+    uri: https://a.org
+    version: 7.7.2
     md5: 3a2
     cf_stacks: [cflinuxfs2]
     MANIFEST
@@ -104,6 +147,8 @@ dependencies:
                            "than one 'default_versions' entry in the buildpack manifest.")
       expect(output).to include("ruby had more " +
                                   "than one 'default_versions' entry in the buildpack manifest.")
+      expect(output).to include("pip had more " +
+                                  "than one 'default_versions' entry in the buildpack manifest.")
       expect(status).to_not be_success
     end
   end
@@ -115,7 +160,9 @@ default_versions:
   - name: python
     version: 3.3.5
   - name: ruby
-    version: 4.3.5
+    version: 4.x
+  - name: pip
+    version: 7.7.x
 dependencies: []
     MANIFEST
     }
@@ -127,8 +174,10 @@ dependencies: []
 
       expect(output).to include("a 'default_versions' entry for python 3.3.5 was specified by the buildpack manifest, " +
                                   "but no 'dependencies' entry for python 3.3.5 was found in the buildpack manifest.")
-      expect(output).to include("a 'default_versions' entry for ruby 4.3.5 was specified by the buildpack manifest, " +
-                                  "but no 'dependencies' entry for ruby 4.3.5 was found in the buildpack manifest.")
+      expect(output).to include("a 'default_versions' entry for ruby 4.x was specified by the buildpack manifest, " +
+                                  "but no 'dependencies' entry for ruby 4.x was found in the buildpack manifest.")
+      expect(output).to include("a 'default_versions' entry for pip 7.7.x was specified by the buildpack manifest, " +
+                                  "but no 'dependencies' entry for pip 7.7.x was found in the buildpack manifest.")
       expect(status).to_not be_success
     end
   end
@@ -141,6 +190,8 @@ default_versions:
     version: 1.1.1
   - name: python
     version: 3.3.5
+  - name: pip
+    version: 7.7.x
 dependencies:
   - name: ruby
     uri: https://a.org
@@ -148,6 +199,11 @@ dependencies:
     md5: 3a2
     cf_stacks: [cflinuxfs2]
   - name: python
+    uri: https://a.org
+    version: 9.9.9
+    md5: 3a2
+    cf_stacks: [cflinuxfs2]
+  - name: pip
     uri: https://a.org
     version: 9.9.9
     md5: 3a2
@@ -164,6 +220,8 @@ dependencies:
                                   "but no 'dependencies' entry for python 3.3.5 was found in the buildpack manifest.")
       expect(output).to include("a 'default_versions' entry for ruby 1.1.1 was specified by the buildpack manifest, " +
                                   "but no 'dependencies' entry for ruby 1.1.1 was found in the buildpack manifest.")
+      expect(output).to include("a 'default_versions' entry for pip 7.7.x was specified by the buildpack manifest, " +
+                                  "but no 'dependencies' entry for pip 7.7.x was found in the buildpack manifest.")
       expect(status).to_not be_success
     end
   end

--- a/spec/integration/default_versions_spec.rb
+++ b/spec/integration/default_versions_spec.rb
@@ -50,31 +50,31 @@ dependencies:
   - name: python
     version: 3.3.5
     uri: http://example.com/
-    md5: 68901bbf8a04e71e0b30aa19c3946b21
+    sha256: aec070645fe53ee3b3763059376134f058cc337247c978add178b6ccdfb0019f
     cf_stacks:
       - cflinuxfs2
   - name: pip
     version: 3.3.4
     uri: http://example.com/
-    md5: 68901bbf8a04e71e0b30aa19c3946b21
+    sha256: aec070645fe53ee3b3763059376134f058cc337247c978add178b6ccdfb0019f
     cf_stacks:
       - cflinuxfs2
   - name: pip
     version: 3.3.2
     uri: http://example.com/
-    md5: 68901bbf8a04e71e0b30aa19c3946b21
+    sha256: aec070645fe53ee3b3763059376134f058cc337247c978add178b6ccdfb0019f
     cf_stacks:
       - cflinuxfs2
   - name: ruby
     version: 5.4.3
     uri: http://example.com/
-    md5: 68901bbf8a04e71e0b30aa19c3946b21
+    sha256: aec070645fe53ee3b3763059376134f058cc337247c978add178b6ccdfb0019f
     cf_stacks:
       - cflinuxfs2
   - name: ruby
     version: 5.5.3
     uri: http://example.com/
-    md5: 68901bbf8a04e71e0b30aa19c3946b21
+    sha256: aec070645fe53ee3b3763059376134f058cc337247c978add178b6ccdfb0019f
     cf_stacks:
       - cflinuxfs2
     MANIFEST
@@ -108,32 +108,32 @@ dependencies:
   - name: python
     uri: https://a.org
     version: 3.3.5
-    md5: 3a2
+    sha256: 3a2
     cf_stacks: [cflinuxfs2]
   - name: python
     uri: https://a.org
     version: 3.3.2
-    md5: 3a2
+    sha256: 3a2
     cf_stacks: [cflinuxfs2]
   - name: ruby
     uri: https://a.org
     version: 4.3.5
-    md5: 3a2
+    sha256: 3a2
     cf_stacks: [cflinuxfs2]
   - name: ruby
     uri: https://a.org
     version: 4.3.2
-    md5: 3a2
+    sha256: 3a2
     cf_stacks: [cflinuxfs2]
   - name: pip
     uri: https://a.org
     version: 7.7.7
-    md5: 3a2
+    sha256: 3a2
     cf_stacks: [cflinuxfs2]
   - name: pip
     uri: https://a.org
     version: 7.7.2
-    md5: 3a2
+    sha256: 3a2
     cf_stacks: [cflinuxfs2]
     MANIFEST
     }
@@ -196,17 +196,17 @@ dependencies:
   - name: ruby
     uri: https://a.org
     version: 9.9.9
-    md5: 3a2
+    sha256: 3a2
     cf_stacks: [cflinuxfs2]
   - name: python
     uri: https://a.org
     version: 9.9.9
-    md5: 3a2
+    sha256: 3a2
     cf_stacks: [cflinuxfs2]
   - name: pip
     uri: https://a.org
     version: 9.9.9
-    md5: 3a2
+    sha256: 3a2
     cf_stacks: [cflinuxfs2]
     MANIFEST
     }

--- a/spec/integration/output_spec.rb
+++ b/spec/integration/output_spec.rb
@@ -33,11 +33,11 @@ describe 'Buildpack packager output' do
     it 'outputs the dependencies downloaded, their versions, and download source url' do
       expect(subject).to include("Downloading go version 1.6.3 from: https://buildpacks.cloudfoundry.org/concourse-binaries/go/go1.6.3.linux-amd64.tar.gz")
       expect(subject).to include("Using go version 1.6.3 with size")
-      expect(subject).to include("go version 1.6.3 matches the manifest provided md5 checksum of 5f7bf9d61d2b0dd75c9e2cd7a87272cc")
+      expect(subject).to include("go version 1.6.3 matches the manifest provided sha256 checksum of 5ac238cd321a66a35c646d61e4cafd922929af0800c78b00375312c76e702e11")
 
       expect(subject).to include("Downloading godep version v74 from: https://pivotal-buildpacks.s3.amazonaws.com/concourse-binaries/godep/godep-v74-linux-x64.tgz")
       expect(subject).to include("Using godep version v74 with size 2.8M")
-      expect(subject).to include("godep version v74 matches the manifest provided md5 checksum of 70220eee9f9e654e0b85887f696b6add")
+      expect(subject).to include("godep version v74 matches the manifest provided sha256 checksum of 6e6761b71e1518bf7716b3f383f10598afe5ce4592e6eea0184f17b85fd93813")
     end
 
     it 'outputs the type of buildpack created, where and its human readable size' do
@@ -51,10 +51,10 @@ describe 'Buildpack packager output' do
 
       it 'outputs the dependencies downloaded, their versions, and cache location' do
         expect(subject).to include("Using go version 1.6.3 from local cache at: #{tmpdir}/.buildpack-packager/cache/https___buildpacks.cloudfoundry.org_concourse-binaries_go_go1.6.3.linux-amd64.tar.gz with size")
-        expect(subject).to include("go version 1.6.3 matches the manifest provided md5 checksum of 5f7bf9d61d2b0dd75c9e2cd7a87272cc")
+        expect(subject).to include("go version 1.6.3 matches the manifest provided sha256 checksum of 5ac238cd321a66a35c646d61e4cafd922929af0800c78b00375312c76e702e11")
 
         expect(subject).to include("Using godep version v74 from local cache at: #{tmpdir}/.buildpack-packager/cache/https___pivotal-buildpacks.s3.amazonaws.com_concourse-binaries_godep_godep-v74-linux-x64.tgz with size")
-        expect(subject).to include("godep version v74 matches the manifest provided md5 checksum of 70220eee9f9e654e0b85887f696b6add")
+        expect(subject).to include("godep version v74 matches the manifest provided sha256 checksum of 6e6761b71e1518bf7716b3f383f10598afe5ce4592e6eea0184f17b85fd93813")
       end
     end
 

--- a/spec/unit/manifest_validator_spec.rb
+++ b/spec/unit/manifest_validator_spec.rb
@@ -41,8 +41,8 @@ describe Buildpack::ManifestValidator do
     end
   end
 
-  context 'with a manifest with an invalid md5 key' do
-    let(:manifest_file_name) { 'manifest_invalid-md6.yml' }
+  context 'with a manifest with an invalid sha256 key' do
+    let(:manifest_file_name) { 'manifest_invalid-sha224.yml' }
 
     it 'reports invalid manifests correctly' do
       expect(validator.valid?).to be(false)
@@ -50,7 +50,7 @@ describe Buildpack::ManifestValidator do
     end
 
     context 'and incorrect defaults' do
-      let(:manifest_file_name) { 'manifest_invalid-md6_and_defaults.yml' }
+      let(:manifest_file_name) { 'manifest_invalid-sha224_and_defaults.yml' }
 
       it 'reports manifest parser errors only' do
         expect(validator).to_not receive(:validate_default_versions)

--- a/spec/unit/manifest_validator_spec.rb
+++ b/spec/unit/manifest_validator_spec.rb
@@ -30,6 +30,15 @@ describe Buildpack::ManifestValidator do
         expect(validator.errors).to be_empty
       end
     end
+
+    context 'with a manifest with windows stacks' do
+      let (:manifest_file_name) { 'manifest_windows.yml' }
+
+      it 'reports valid manifests correctly' do
+        expect(validator.valid?).to be(true)
+        expect(validator.errors).to be_empty
+      end
+    end
   end
 
   context 'with a manifest with an invalid md5 key' do


### PR DESCRIPTION
This fixes building newer buildpacks with sha256 checksums instead of md5.